### PR TITLE
Added name to metadata.rb for support in Berkshelf

### DIFF
--- a/le/metadata.rb
+++ b/le/metadata.rb
@@ -1,3 +1,4 @@
+name "le_chef"
 maintainer "Caroline Fenlon"
 maintainer_email "carfenlon@gmail.com"
 license "Apache 2.0"


### PR DESCRIPTION
When trying to use Berkshelf to load the cookbook, there is an error thrown indicating the metadata.rb file requires a name.

![image](https://cloud.githubusercontent.com/assets/3450927/5398873/1714877a-8134-11e4-84e8-6e765b073a44.png)
